### PR TITLE
Set correct word wrap configuration on editor initialization

### DIFF
--- a/org.eclipse.texlipse/source/org/eclipse/texlipse/actions/TexWordWrapAction.java
+++ b/org.eclipse.texlipse/source/org/eclipse/texlipse/actions/TexWordWrapAction.java
@@ -54,10 +54,19 @@ public class TexWordWrapAction implements IEditorActionDelegate, IActionDelegate
         public void propertyChange(PropertyChangeEvent event) {
             String ev = event.getProperty();
             if (ev.equals("wrapType")) {
-                if (!off) {
-                    setType();
-                }
+                configureWordWrap();
             }
+        }
+    }
+
+    /**
+     * Performs the operations needed on wrap configuration changes
+     *
+     * @author Leonardo Montecchi
+     */
+    private void configureWordWrap() {
+        if (!off) {
+            setType();
         }
     }
 
@@ -66,6 +75,7 @@ public class TexWordWrapAction implements IEditorActionDelegate, IActionDelegate
      */
     public void init(IAction action) {
         action.setChecked(!off);
+        configureWordWrap();
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
This should solve an annoying issue (#53) for which the word wrap configuration is not correctly loaded on editor initialization.